### PR TITLE
fix: Remove duplicate watchWebhookEnabled declaration

### DIFF
--- a/src/components/addresses/edit-address-dialog.tsx
+++ b/src/components/addresses/edit-address-dialog.tsx
@@ -102,8 +102,6 @@ export function EditAddressDialog({
 
   const watchWebhookEnabled = form.watch("webhookEnabled");
 
-  const watchWebhookEnabled = form.watch("webhookEnabled");
-
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
       const webhook =


### PR DESCRIPTION
## Summary
- Remove duplicate const declaration in EditAddressDialog component

## Changes
- Removed duplicate `const watchWebhookEnabled = form.watch("webhookEnabled");` declaration on line 105

## Test plan
- Component should work without any issues
- No TypeScript errors
- Webhook functionality remains unchanged